### PR TITLE
Beautify before Markdown or Kirbytags are parsed.

### DIFF
--- a/textbeautifier/textbeautifier.php
+++ b/textbeautifier/textbeautifier.php
@@ -2,6 +2,6 @@
 // Filter that beautifies Kirbytext before outout
 
 // Add hair spaces around en/em dashes
-kirbytext::$post[] = function($kirbytext, $value) {
-	return preg_replace("/(\S)(—|–)(\S)/", "$1&#8202;$2&#8202;$3", $value);
+kirbytext::$pre[] = function($kirbytext, $text) {
+	return preg_replace("/(\S)(---|--|—|–)(\S)/", "$1&#8202;$2&#8202;$3", $value);
 };

--- a/textbeautifier/textbeautifier.php
+++ b/textbeautifier/textbeautifier.php
@@ -2,6 +2,6 @@
 // Filter that beautifies Kirbytext before outout
 
 // Add hair spaces around en/em dashes
-kirbytext::$pre[] = function($kirbytext, $text) {
+kirbytext::$pre[] = function($kirbytext, $value) {
 	return preg_replace("/(\S)(---|--|—|–)(\S)/", "$1&#8202;$2&#8202;$3", $value);
 };


### PR DESCRIPTION
Makes it also possible to add hair spaces around en/em dashes when using smartypants syntax for em (---) and en (--) dashes.